### PR TITLE
address pr #9 comments, fix useLoaderData and useFetcher

### DIFF
--- a/packages/svelte/LICENSE.md
+++ b/packages/svelte/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2022 Matt Brophy <matt@brophy.org>
+Copyright 2022 Austin Crim <aust.crim@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,20 +1,20 @@
-# remix-router-vue
+# remix-router-svelte
 
-Vue UI implementation of the `react-router-dom` API (driven by `@remix-run/router`)
+Svelte UI implementation of the `react-router-dom` API (driven by `@remix-run/router`)
 
 **⚠️ This repo is very much in an alpha state and production usage is _highly discouraged_**
 
 ## Installation
 
 ```bash
-npm install remix-router-vue
+npm install remix-router-svelte
 
 # or
 
-yarn add remix-router-vue
+yarn add remix-router-svelte
 ```
 
-_Note: If you are using TypeScript you will need to use `patch-package` and copy the `@remix-run+router+0.1.0.patch` patch from this repo to internally change the `RouteObject.element` type from `React.ReactNode` to `any` for use with Vue components._
+_Note: If you are using TypeScript you will need to use `patch-package` and copy the `@remix-run+router+0.1.0.patch` patch from this repo to internally change the `RouteObject.element` type from `React.ReactNode` to `any` for use with Svelte components._
 
 ## Notable API Differences
 
@@ -22,17 +22,15 @@ _Note: If you are using TypeScript you will need to use `patch-package` and copy
 
 ## Example Usage
 
-Please refer to the [beta docs for `react-router@6.4`][rr-beta-docs] for reference on the APIs in question, but the following is a simple example of how to leverage `remix-router-vue` in a Vue application. You may also refer to the [reference application][reference-app] for a more extensive usage example.
+Please refer to the [beta docs for `react-router@6.4`][rr-beta-docs] for reference on the APIs in question, but the following is a simple example of how to leverage `remix-router-svelte` in a Svelte application. You may also refer to the [reference application][reference-app] for a more extensive usage example.
 
-**App.vue**
+**App.svelte**
 
 ```html
-<script setup>
-  import { DataBrowserRouter } from "remix-router-vue";
-  import { h } from "vue";
-
-  import Layout from "./Layout.vue";
-  import Index, { loader as indexLoader } from "./Index.vue";
+<script>
+  import { DataBrowserRouter } from "remix-router-svelte";
+  import Layout from "./Layout.svelte";
+  import Index, { loader as indexLoader } from "./Index.svelte";
 
   // Define your routes in a nested array, providing loaders and actions where
   // appropriate
@@ -51,36 +49,32 @@ Please refer to the [beta docs for `react-router@6.4`][rr-beta-docs] for referen
   ];
 
   // Provide a fallbackElement to be displayed during the initial data load
-  const fallbackElement = () => h("p", "Loading..."),
+  const fallbackElement = "<p>loading...</p>";
 </script>
 
-<template>
-  <DataBrowserRouter :routes="routes" :fallbackElement="fallbackElement" />
-</template>
+<DataBrowserRouter {routes} {fallbackElement} />
 ```
 
-**Layout.vue**
-
-```html
-<script setup>
-  import { Outlet } from "remix-router-vue";
-</script>
-
-<template>
-  <!-- Render global-layout stuff here, such as a header and nav bar -->
-  <h1>Welcome to my Vue Application!</h1>
-  <nav><!-- nav links --></nav>
-
-  <!-- Render matching child routes via <Outlet /> -->
-  <Outlet />
-</template>
-```
-
-**Index.vue**
+**Layout.svelte**
 
 ```html
 <script>
-  import { useLoaderData } from 'remix-router-vue';
+  import { Outlet } from "remix-router-svelte";
+</script>
+
+<!-- Render global-layout stuff here, such as a header and nav bar -->
+<h1>Welcome to my Svelte Application!</h1>
+<nav><!-- nav links --></nav>
+
+<!-- Render matching child routes via <Outlet /> -->
+<Outlet />
+```
+
+**Index.svelte**
+
+```html
+<script context="module">
+  import { useLoaderData } from 'remix-router-svelte';
 
   export async function loader() {
     // Load your data here and return whatever you need access to in the UI
@@ -88,15 +82,15 @@ Please refer to the [beta docs for `react-router@6.4`][rr-beta-docs] for referen
   };
 </script>
 
-<script setup>
-  // Use the useLoaderData composition API method to access the data returned
+<script>
+  // Use the useLoaderData method to access a store of the data returned
   // from your loader
   const data = useLoaderData();
 </script>
 
 <template>
   <p>Check out my data!</p>
-  <pre>{{ data }}</pre>
+  <pre>{$data}</pre>
 </template>
 ```
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-router-svelte",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "description": "A Svelte UI layer for nested + data-driven routing via @remix-run/router",
   "author": "aust.crim@gmail.com",
   "license": "MIT",
@@ -44,7 +44,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remix-run/router": "0.1.0",
+    "@remix-run/router": "0.2.0-pre.2",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.49",
     "svelte": "^3.48.0"
   },

--- a/packages/svelte/reference-app/components/TaskItem.svelte
+++ b/packages/svelte/reference-app/components/TaskItem.svelte
@@ -16,7 +16,6 @@
   style="display: inline"
   action="/tasks"
   method="post"
-  fetcherKey={$fetcher.key}
 >
   <button type="submit" name="taskId" value={task.id} disabled={isDeleting}>
     {isDeleting ? "Deleting..." : "❌"}

--- a/packages/svelte/reference-app/routes/Nested/Child.svelte
+++ b/packages/svelte/reference-app/routes/Nested/Child.svelte
@@ -1,7 +1,6 @@
 <script lang="ts" context="module">
   import type { LoaderFunction } from "@remix-run/router";
   import { json, useLoaderData } from "remix-router-svelte";
-  import { onDestroy } from "svelte";
   import { sleep } from "~/utils";
 
   interface LoaderData {
@@ -20,5 +19,4 @@
 
 <h3>Child Route</h3>
 
-<!-- currently broken! -->
-<p id="child">Child data: {data.data}</p>
+<p id="child">Child data: {$data.data}</p>

--- a/packages/svelte/reference-app/routes/Nested/Parent.svelte
+++ b/packages/svelte/reference-app/routes/Nested/Parent.svelte
@@ -18,6 +18,6 @@
 
 <h2>Parent Layout</h2>
 <p id="parent">
-  Parent data: {data.data}
+  Parent data: {$data.data}
 </p>
 <Outlet />

--- a/packages/svelte/src/components/DataBrowserRouter/DataBrowserRouter.svelte
+++ b/packages/svelte/src/components/DataBrowserRouter/DataBrowserRouter.svelte
@@ -5,7 +5,7 @@
     type RouteObject,
   } from "@remix-run/router";
   import { RouterContextSymbol } from "../../contexts/";
-  import { setContext } from "svelte";
+  import { onDestroy, setContext } from "svelte";
   import { writable } from "svelte/store";
   import Outlet from "../Outlet/Outlet.svelte";
 
@@ -22,6 +22,9 @@
   router.subscribe(stateRef.set);
 
   setContext(RouterContextSymbol, { router, state: stateRef });
+  onDestroy(() => {
+    router.dispose();
+  });
 </script>
 
 {#if !$stateRef.initialized}

--- a/packages/svelte/src/components/DataBrowserRouter/DataBrowserRouter.svelte
+++ b/packages/svelte/src/components/DataBrowserRouter/DataBrowserRouter.svelte
@@ -5,7 +5,7 @@
     type RouteObject,
   } from "@remix-run/router";
   import { RouterContextSymbol } from "../../contexts/";
-  import { onDestroy, setContext } from "svelte";
+  import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import Outlet from "../Outlet/Outlet.svelte";
 
@@ -19,12 +19,9 @@
   }).initialize();
 
   let stateRef = writable(router.state);
-  let unsub = router.subscribe(stateRef.set);
+  router.subscribe(stateRef.set);
 
   setContext(RouterContextSymbol, { router, state: stateRef });
-  onDestroy(() => {
-    unsub();
-  });
 </script>
 
 {#if !$stateRef.initialized}

--- a/packages/svelte/src/components/Form/Form.svelte
+++ b/packages/svelte/src/components/Form/Form.svelte
@@ -5,6 +5,7 @@
     useFormAction,
     submitForm,
     getRouterContext,
+    getRouteContext,
   } from "remix-router-svelte";
 
   export let replace: boolean = false;
@@ -13,6 +14,7 @@
   type HTMLFormSubmitter = HTMLButtonElement | HTMLInputElement;
 
   let { router } = getRouterContext();
+  let routeId = getRouteContext().id;
   let defaultAction = useFormAction($$restProps.action as string);
 
   function submit(event: SubmitEvent) {
@@ -29,6 +31,7 @@
         method: $$restProps.method as FormMethod,
         replace,
       },
+      routeId,
       fetcherKey
     );
   }

--- a/packages/svelte/src/components/Form/Form.svelte
+++ b/packages/svelte/src/components/Form/Form.svelte
@@ -31,8 +31,8 @@
         method: $$restProps.method as FormMethod,
         replace,
       },
-      routeId,
-      fetcherKey
+      fetcherKey,
+      routeId
     );
   }
 </script>

--- a/packages/svelte/src/remix-router-svelte.ts
+++ b/packages/svelte/src/remix-router-svelte.ts
@@ -136,8 +136,8 @@ export function useFetcher<TData = unknown>(): Readable<
           defaultAction,
           target,
           options,
-          routeId,
-          fetcherKey
+          fetcherKey,
+          routeId
         );
       },
       load(href: string) {
@@ -163,8 +163,8 @@ export function submitForm(
   defaultAction: string,
   target: SubmitTarget,
   options: SubmitOptions = {},
-  routeId: string,
-  fetcherKey?: string
+  fetcherKey?: string,
+  routeId?: string
 ): void {
   if (typeof document === "undefined") {
     throw new Error("Unable to submit during server render");

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ command, mode }) => {
         output: {
           globals: {
             "@remix-run/router": "Router",
+            svelte: "Svelte",
           },
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,11 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-0.1.0.tgz#9dee1610f5ba730e4c67e5de517912f71c627031"
   integrity sha512-mK2wZWAFsijTGIk7ZhKvEAzU7qIS6F6RhPy5AiEosaEs3mB3J2NvUWRoN3W74V+5Jju/AisT5NaM2pIbnfGXWg==
 
+"@remix-run/router@0.2.0-pre.2":
+  version "0.2.0-pre.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-0.2.0-pre.2.tgz#66ac8e95fcbf8a2cc48cd25823f3df29040ca83c"
+  integrity sha512-DRgTrJZ7R1nGI0EUNsEYYcXU+AASz6CE7rnksTYnIdVEBztygwbOlKRNnPyufQIcQs2kV/0cKf1FpfZfPMhMjQ==
+
 "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"


### PR DESCRIPTION
`useLoaderData` was actually still broken in my previous PR (#9). I noodled for a long time on why the Svelte and Vue reactivity systems are subtly different, but I decided a simple guard is good enough for now.

I also figured out a way to compose the `Form` component and pass along the appropriate `fetcherKey` for `useFetcher`. Will need to pull out a `FormImpl` component in a future PR to hide the `fetcherKey` prop from the public API.