### PR TITLE
Rewrite useFormAction to respect basename

### DIFF
--- a/packages/svelte/src/remix-router-svelte.ts
+++ b/packages/svelte/src/remix-router-svelte.ts
@@ -190,7 +190,6 @@ export function useFormAction(action = "."): string {
   let resolvedAction = action ?? ".";
   let location = useLocation();
   let { pathname, search, hash } = get(location);
-  console.log(getPathContributingMatches(matches));
   let path = resolveTo(
     resolvedAction,
     getPathContributingMatches(matches).map((match) => match.pathnameBase),

--- a/packages/svelte/src/remix-router-svelte.ts
+++ b/packages/svelte/src/remix-router-svelte.ts
@@ -14,6 +14,8 @@ import {
   type AgnosticRouteMatch,
   createBrowserHistory,
   createHashHistory,
+  joinPaths,
+  createPath,
 } from "@remix-run/router";
 import { onDestroy, type SvelteComponent } from "svelte";
 import { derived, get, writable, type Readable } from "svelte/store";
@@ -172,24 +174,50 @@ export function useMatches() {
   );
 }
 
-export function useFormAction(action = "."): string {
-  let { router } = getRouterContext();
-  let route = getRouteContext();
-  let location = useLocation();
-  let { pathname } = get(location);
+function getPathContributingMatches(matches: DataRouteMatch[]) {
+  return matches.filter(
+    (match, index) =>
+      index === 0 ||
+      (!match.route.index &&
+        match.pathnameBase !== matches[index - 1].pathnameBase)
+  );
+}
 
+export function useFormAction(action = "."): string {
+  let basename = getRouterContext().router.basename;
+  let matches = getRouterContext().router.state.matches;
+  let [match] = matches.slice(-1);
+  let resolvedAction = action ?? ".";
+  let location = useLocation();
+  let { pathname, search, hash } = get(location);
+  console.log(getPathContributingMatches(matches));
   let path = resolveTo(
-    action,
-    router.state.matches.map((match) => match.pathnameBase),
+    resolvedAction,
+    getPathContributingMatches(matches).map((match) => match.pathnameBase),
     pathname
   );
-
-  let search = path.search;
-  if (action === "." && route.index) {
-    search = search ? search.replace(/^\?/, "?index&") : "?index";
+  if (action == null) {
+    path.search = search;
+    path.hash = hash;
+    if (match.route.index) {
+      let params = new URLSearchParams(path.search);
+      params.delete("index");
+      path.search = params.toString() ? `?${params.toString()}` : "";
+    }
   }
 
-  return path.pathname + search;
+  if ((!action || action === ".") && match.route.index) {
+    path.search = path.search
+      ? path.search.replace(/^\?/, "?index&")
+      : "?index";
+  }
+
+  if (basename !== "/") {
+    path.pathname =
+      path.pathname === "/" ? basename : joinPaths([basename, path.pathname]);
+  }
+
+  return createPath(path);
 }
 
 let fetcherId = 0;


### PR DESCRIPTION
Not a lot of creative coding was done here, I just copied how `react-router-dom` implements `useFormAction` and adapted it to svelte.

Running `yarn validate` cypress gets stuck on 
```
1: starting server using command "npm run integration:start"
and when url "[ 'http-get://localhost:3000/' ]" is responding with HTTP status code 200
running tests using command "npm run integration:test"

> react-router-dom-stub@0.0.0 integration:start
> vite build && vite preview --port 3000

vite v2.9.9 building for production...
✓ 49 modules transformed.
dist/index.html                  0.33 KiB
dist/assets/index.66c49214.css   0.06 KiB / gzip: 0.07 KiB
dist/assets/index.859b56ff.js    187.67 KiB / gzip: 60.71 KiB
  > Local: http://localhost:3000/
  > Network: use `--host` to expose
```
not sure what's up with that.

This same code inside my repo that uses react-router-svelte (directly in node_modules) fixes the problem described in this issue https://github.com/brophdawg11/remix-routers/issues/22

Please verify all tests pass properly.

Link to `useFormAction` in `react-router-dom` for verification:
https://github.com/remix-run/react-router/blob/main/packages/react-router-dom/index.tsx#L873

Also link to `useResolvedPath` in `react-router-dom` where I copied how `resolveTo` is used:
https://github.com/remix-run/react-router/blob/bf5afbed559926ed35ac9180881c78c426a29230/packages/react-router/lib/hooks.tsx#L271
