### PR TITLE
Use parse from node:path to parse cwd

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "cypress";
+import { parse } from "node:path";
 
-const library = process.cwd().split("/").slice(-1)[0].replace("-stub", "");
+const library = parse(process.cwd()).name.replace("-stub", "");
 console.log(`Running Cypress integration tests for library: ${library}`);
 
 module.exports = defineConfig({


### PR DESCRIPTION
To get libray name for which we are running test against, this is the code we are using

```ts
const library = process.cwd().split("/").slice(-1)[0].replace("-stub", "");
console.log(`Running Cypress integration tests for library: ${library}`);
```
This would not work when we are running test in windows. Since the filepath delimiters in windows are "\" not "/". 

This causes to cypress test fail

Before 
![image](https://user-images.githubusercontent.com/52579256/209431778-37bf9562-f97a-4664-b0d7-0a87a7c0d00e.png)

After 
![image](https://user-images.githubusercontent.com/52579256/209431818-d5cd13d4-7afb-4a54-b493-b8cca78ff665.png)


To fix these we use `parse` from `node:path` to parse the `cwd` 